### PR TITLE
Discontinuous qpoints

### DIFF
--- a/tp/cli/cli.py
+++ b/tp/cli/cli.py
@@ -1595,11 +1595,23 @@ def converge_phonons(band_yaml, bandmin, bandmax, colour, alpha, linestyle,
         dosax = ax[1]
         ax = ax[0]
 
-    tp.plot.phonons.add_multi(ax, data, colour=colour, linestyle=linestyle,
-                              marker=marker, label=label, bandmin=bandmin,
-                              bandmax=bandmax, alpha=alpha,
-                              xmarkkwargs={'color':     xmarkcolour,
-                                           'linestyle': xmarklinestyle})
+    if len(band_yaml) == 1:
+        try:
+            colour = mpl.cm.get_cmap(colour)([0])
+        except ValueError:
+            pass
+        tp.plot.phonons.add_dispersion(ax, data[0], colour=colour,
+                                       linestyle=linestyle[0], marker=marker[0],
+                                       label=label, bandmin=bandmin,
+                                       bandmax=bandmax, alpha=alpha,
+                                       xmarkkwargs={'color':     xmarkcolour,
+                                                 'linestyle': xmarklinestyle})
+    else:
+        tp.plot.phonons.add_multi(ax, data, colour=colour, linestyle=linestyle,
+                                  marker=marker, label=label, bandmin=bandmin,
+                                  bandmax=bandmax, alpha=alpha,
+                                  xmarkkwargs={'color':     xmarkcolour,
+                                               'linestyle': xmarklinestyle})
     if dos is not None:
         dosdata = tp.data.load.phonopy_dos(dos, poscar, atoms)
         tp.plot.frequency.add_dos(dosax, dosdata, projected=projected,

--- a/tp/plot/phonons.py
+++ b/tp/plot/phonons.py
@@ -186,9 +186,17 @@ def add_dispersion(ax, data, sdata=None, bandmin=None, bandmax=None, main=True,
 
     # plotting
 
+    # avoid connecting bands at disconnected q-points
+    split_indices = [0, *np.where(np.diff(x) == 0)[0] + 1, len(x)]
     for n in range(len(f[0])):
-        ax.plot(x, f[:,n], color=colour[n], linestyle=linestyle[n],
-                marker=marker[n], label=label[n], **kwargs)
+        for i in range(len(split_indices)-1):
+            starting_index = split_indices[i]
+            ending_index = split_indices[i+1]
+            x_i = x[starting_index:ending_index]
+            f_ni = f[starting_index:ending_index, n]
+            label_ni = label[n] if i == 0 else None
+            ax.plot(x_i, f_ni, color=colour[n], linestyle=linestyle[n],
+                    label=label_ni, marker=marker[n], **kwargs)
 
     # axes formatting
 

--- a/tp/plot/phonons.py
+++ b/tp/plot/phonons.py
@@ -585,13 +585,21 @@ def add_alt_dispersion(ax, data, pdata, quantity, bandmin=None, bandmax=None,
 
     # plotting
 
+    # avoid connecting bands at disconnected q-points
+    split_indices = [0, *np.where(np.diff(x2) == 0)[0] + 1, len(x2)]
     for n in range(len(y2[0])):
         if scatter:
             ax.scatter(x2, y2[:,n], color=colour[n], linestyle=linestyle[n],
                        label=label[n], marker=marker[n], **kwargs)
         else:
-            ax.plot(x2, y2[:,n], color=colour[n], linestyle=linestyle[n],
-                    label=label[n], marker=marker[n], **kwargs)
+            for i in range(len(split_indices)-1):
+                starting_index = split_indices[i]
+                ending_index = split_indices[i+1]
+                x2_i = x2[starting_index:ending_index]
+                y2_ni = y2[starting_index:ending_index, n]
+                label_ni = label[n] if i == 0 else None
+                ax.plot(x2_i, y2_ni, color=colour[n], linestyle=linestyle[n],
+                        label=label_ni, marker=marker[n], **kwargs)
 
     # axes formatting
 


### PR DESCRIPTION
Hello!

First of all, let me thank you for writing this fantastic package. It's been quite useful for me and seems very easily extensible and customizable.

**Background:**
For some crystal symmetries, some common softwares have conventions that construct a q-path that is discontinuous in the Brillouin zone.
E.g. BCC (Spacegroup #229) q-paths have X|R (SeekPath) or H|P (pymatgen)

**Problem:**
The current plotting joins phonon bands across this discontinuity, although it is mostly only visible if the (plot) linewdith of the band is thicker than the linewidth of the vlines at these q-points.

**Solution:**
These discontinuities can be found by checking for two adjacent x values in the q-path that have the same value. You can then fix this issue by splitting the x and frequency arrays across each discontinuity and making separate plotting calls for each "split". In the case where there are no q-points with discontinuities, this implementation results in the same plotting behavior as before.

**Example:** 
BCC Iron (Fe) with spin polarization turned off displays imaginary modes. In Fe_229_nospin_original.pdf, note the band connection along H|P. In Fe_229_nospin_updated.pdf, the suggested fix is applied and the previous vertical line joining the bands is not present.
[Fe_229_nospin_original.pdf](https://github.com/user-attachments/files/17940361/Fe_229_nospin_original.pdf)
[Fe_229_nospin_updated.pdf](https://github.com/user-attachments/files/17940363/Fe_229_nospin_updated.pdf)

**Further comments:**
I'd be very happy to address any feedback!
* I only updated `add_dispersion` and `add_alt_dispersion`, but this fix also addresses this issue automatically for `add_multi`. There might be cases where this still occurs for some of the other phonon plotting functions if linestyle is used with `scatter`.
* I'm not sure if I should have also changed `ax.scatter()` for `add_alt_dispersion`. If I'm completely honest, I'm not sure I understand the use cases for `ax.scatter` with linestyle vs `ax.plot` with markers.
* I also acknowledge that the way I implemented `label_ni` is probably not optimal, although it let me leave the `tile_properties()` calls alone.
* There's a difference in the ylimits (bottom) between these plots from another change I made, which is only relevant for cases where there are imaginary modes. I'm drafting another pull request for this.